### PR TITLE
Build script fix and mupdf reload

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1728,6 +1728,7 @@ echo-list	= for x in $1; do $(ECHO) "$$x"; done
 
 .PHONY: all
 all: $(default_pdf_targets) ;
+	killall -q -SIGHUP mupdf || true
 
 .PHONY: all-pdf
 all-pdf: $(default_pdf_targets) ;

--- a/Makefile.in
+++ b/Makefile.in
@@ -1728,7 +1728,6 @@ echo-list	= for x in $1; do $(ECHO) "$$x"; done
 
 .PHONY: all
 all: $(default_pdf_targets) ;
-	killall -q -SIGHUP mupdf || true
 
 .PHONY: all-pdf
 all-pdf: $(default_pdf_targets) ;

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 from __future__ import print_function, division
 

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 from __future__ import print_function, division
 


### PR DESCRIPTION
This pull request adds two things:

- Since the build script complains about wrong python version used on a python 3.x system, I set the shebang to force python 2.x on my system. This works on Gentoo when the correct python versions are installed in different slots. Don,t know about other distros, but might work in same/similar way there.
Should we port the script to Python 3? Usually not a big deal.
